### PR TITLE
adding compatibility for laravel 10 by adding support for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3]
-        laravel: [11]
+        php: [8.1, 8.2, 8.3]
+        laravel: [10, 11]
+        exclude:
+          - php: 8.1
+            laravel: 11
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ A package to easily make use of [Hugeicons](https://hugeicons.com/)(Free version
 
 For a full list of available icons see [the SVG directory](resources/svg) or preview them at [hugeicons.com](https://hugeicons.com/).
 
-> **Note**  
+> **Note**
 > This package only includes the Hugeicons's free set, for more please visit the link. [Hugeicons Pro](https://hugeicons.com/pricing)
 
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.1 or higher
 - Laravel 10.0 or higher
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
         }
     ],
     "require": {
-        "php": "~8.2.0|~8.3.0",
-        "blade-ui-kit/blade-icons": "^1.6",
-        "illuminate/support": "^11.0"
+        "php": "^8.1",
+        "blade-ui-kit/blade-icons": "^1.1",
+        "illuminate/support": "^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0",
-        "phpunit/phpunit": "^10.0"
+        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Adding support for PHP 8.1 to make it compatible with Laravel 10 [Laravel 10 support PHP 8.1](https://laravel.com/docs/10.x/releases)
- Updating Test Matrix to avoid Laravel 11 with PHP 8.1